### PR TITLE
Fix Learn More button and add founder profiles

### DIFF
--- a/about.qmd
+++ b/about.qmd
@@ -5,10 +5,21 @@
     Cultural Health Connect was founded with the aim of bridging cultural gaps in healthcare. We are dedicated to providing culturally relevant health and lifestyle education to immigrant communities in East County San Diego. Our mission is to empower community members by integrating traditional cultural values with modern healthcare practices.
   </p>
 
-  <h2>Our Founders</h2>
-  <p>
-    Details about our founders and their inspiring journeys will be shared soon. Stay tuned as we introduce the passionate individuals behind Cultural Health Connect.
-  </p>
+<h2>Our Founders</h2>
+<div class="founder-profile">
+  <img src="Images/founder1.jpg" alt="Founder 1">
+  <p>Placeholder text about Founder 1. This paragraph will highlight their background, expertise and the passion they bring to Cultural Health Connect.</p>
+</div>
+
+<div class="founder-profile">
+  <img src="Images/founder2.jpg" alt="Founder 2">
+  <p>Placeholder text about Founder 2. Share an overview of their journey and what inspires them to serve the community through CHC.</p>
+</div>
+
+<div class="founder-profile">
+  <img src="Images/founder3.jpg" alt="Founder 3">
+  <p>Placeholder text about Founder 3. A short biography here will showcase their role and vision for the organization.</p>
+</div>
 </div>
 
 <footer>

--- a/docs/about.html
+++ b/docs/about.html
@@ -135,9 +135,20 @@ Cultural Health Connect was founded with the aim of bridging cultural gaps in he
 <h2 class="anchored">
 Our Founders
 </h2>
-<p>
-Details about our founders and their inspiring journeys will be shared soon. Stay tuned as we introduce the passionate individuals behind Cultural Health Connect.
-</p>
+<div class="founder-profile">
+<img src="Images/founder1.jpg" alt="Founder 1">
+<p>Placeholder text about Founder 1. This paragraph will highlight their background, expertise and the passion they bring to Cultural Health Connect.</p>
+</div>
+
+<div class="founder-profile">
+<img src="Images/founder2.jpg" alt="Founder 2">
+<p>Placeholder text about Founder 2. Share an overview of their journey and what inspires them to serve the community through CHC.</p>
+</div>
+
+<div class="founder-profile">
+<img src="Images/founder3.jpg" alt="Founder 3">
+<p>Placeholder text about Founder 3. A short biography here will showcase their role and vision for the organization.</p>
+</div>
 </div>
 <footer>
 © 2025 Cultural Health Connect

--- a/docs/index.html
+++ b/docs/index.html
@@ -139,7 +139,7 @@ Empowering healthier lives in East County San Diego—where culture meets clinic
 At Cultural Health Connect, our mission is to deliver the most up-to-date, evidence-based guidance on managing chronic disease through diet and lifestyle—tailored specifically to the Middle Eastern and Mexican communities of El Cajon. We believe in the power of moderation rather than elimination, working alongside our community to find practical, sustainable health solutions that honor and respect cherished cultural traditions—especially those centered on food.
 </p>
 <div style="text-align:center; margin-top:2rem;">
-<p><a href="About.html" class="btn">Learn More</a> <!-- href="Programs.html" class="btn">Our Programs</--> <a href="Contact.html" class="btn">Contact Us</a> <a href="Donate.html" class="btn">Donate</a></p>
+<p><a href="about.html" class="btn">Learn More</a> <!-- <a href="Programs.html" class="btn">Our Programs</a> --> <a href="Contact.html" class="btn">Contact Us</a> <a href="Donate.html" class="btn">Donate</a></p>
 </div>
 <footer>
 © 2025 Cultural Health Connect – All Rights Reserved

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -87,3 +87,24 @@ img {
   max-width: 100%;
   height: auto;
 }
+
+/* Founder Profile Styles */
+.founder-profile {
+  display: flex;
+  align-items: center;
+  margin: 2rem 0;
+}
+
+.founder-profile:nth-child(even) {
+  flex-direction: row-reverse;
+}
+
+.founder-profile img {
+  width: 150px;
+  border-radius: 50%;
+  margin: 0 1rem;
+}
+
+.founder-profile p {
+  flex: 1;
+}

--- a/index.qmd
+++ b/index.qmd
@@ -14,8 +14,8 @@
     At Cultural Health Connect, our mission is to deliver the most up-to-date, evidence-based guidance on managing chronic disease through diet and lifestyle—tailored specifically to the Middle Eastern and Mexican communities of El Cajon. We believe in the power of moderation rather than elimination, working alongside our community to find practical, sustainable health solutions that honor and respect cherished cultural traditions—especially those centered on food.
   </p>
   <div style="text-align:center; margin-top:2rem;">
-<a href="About.html" class="btn">Learn More</a>
-<!-- href="Programs.html" class="btn">Our Programs</-->
+<a href="about.html" class="btn">Learn More</a>
+<!-- <a href="Programs.html" class="btn">Our Programs</a> -->
 <a href="Contact.html" class="btn">Contact Us</a>
 <a href="Donate.html" class="btn">Donate</a>
 </div>

--- a/styles.css
+++ b/styles.css
@@ -87,3 +87,24 @@ img {
   max-width: 100%;
   height: auto;
 }
+
+/* Founder Profile Styles */
+.founder-profile {
+  display: flex;
+  align-items: center;
+  margin: 2rem 0;
+}
+
+.founder-profile:nth-child(even) {
+  flex-direction: row-reverse;
+}
+
+.founder-profile img {
+  width: 150px;
+  border-radius: 50%;
+  margin: 0 1rem;
+}
+
+.founder-profile p {
+  flex: 1;
+}


### PR DESCRIPTION
## Summary
- make "Learn More" on homepage link to the About page
- add founder profile section to About with placeholders
- style founder profiles in CSS

## Testing
- `quarto render about.qmd index.qmd` *(fails: produced no log)*

------
https://chatgpt.com/codex/tasks/task_e_6855b0ea2aa88323a6fa7fbf5ee4a2d2